### PR TITLE
Relax base upper bound for GHC 8.0.1, add stack.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 cabal.sandbox.config
 .cabal-sandbox
+.stack-work

--- a/barrier.cabal
+++ b/barrier.cabal
@@ -45,7 +45,7 @@ library
                        Graphics.Badge.Barrier.Style.Flat
                        Graphics.Badge.Barrier.Style.FlatSquare
                        Graphics.Badge.Barrier.Style.Plastic
-  build-depends:       base                 >=4.6  && <4.9
+  build-depends:       base                 >=4.6  && <5
                      , template-haskell
                      , unordered-containers >=0.2  && <0.3
                      , blaze-svg            >=0.3  && <0.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-7.12
+packages:
+- '.'


### PR DESCRIPTION
Fixes #3.

We would like to upgrade purescript/pursuit to LTS 7.12, but we need this package to support the latest `base`.

Thanks!