### PR TITLE
Update version bounds for bytestring

### DIFF
--- a/barrier.cabal
+++ b/barrier.cabal
@@ -50,7 +50,7 @@ library
                      , unordered-containers >=0.2  && <0.3
                      , blaze-svg            >=0.3  && <0.4
                      , text                 >=1.1  && <1.3
-                     , bytestring           >=0.10 && <0.11
+                     , bytestring           >=0.10 && <0.12
   hs-source-dirs:      src
   ghc-options:         -Wall -O2
   default-language:    Haskell2010


### PR DESCRIPTION
This updates the version so it compiles with GHC 9.2.3.

@philopon would you be open to merge this and publish a new version?