### PR TITLE
Bump more dependencies

### DIFF
--- a/barrier.cabal
+++ b/barrier.cabal
@@ -50,7 +50,7 @@ library
                      , unordered-containers >=0.2  && <0.3
                      , blaze-svg            >=0.3  && <0.4
                      , text                 >=1.1  && <2.1
-                     , bytestring           >=0.10 && <0.12
+                     , bytestring           >=0.10 && <0.13
   hs-source-dirs:      src
   ghc-options:         -Wall -O2
   default-language:    Haskell2010

--- a/barrier.cabal
+++ b/barrier.cabal
@@ -49,7 +49,7 @@ library
                      , template-haskell
                      , unordered-containers >=0.2  && <0.3
                      , blaze-svg            >=0.3  && <0.4
-                     , text                 >=1.1  && <1.3
+                     , text                 >=1.1  && <2.1
                      , bytestring           >=0.10 && <0.12
   hs-source-dirs:      src
   ghc-options:         -Wall -O2
@@ -72,7 +72,7 @@ executable barrier-example
     buildable:         True
     build-depends:     base
                      , bytestring
-                     , lens-family-core >=1.2  && <1.3
+                     , lens-family-core >=1.2  && <2.2
                      , barrier
   else
     buildable:         False
@@ -86,7 +86,7 @@ executable barrier-test-result-generator
     buildable:         True
     build-depends:     base
                      , bytestring
-                     , lens-family-core >=1.2  && <1.3
+                     , lens-family-core >=1.2  && <2.2
                      , barrier
   else
     buildable:         False
@@ -99,8 +99,8 @@ test-suite tasty
   main-is:             tasty.hs
   build-depends:       base
                      , bytestring
-                     , lens-family-core >=1.2  && <1.3
-                     , tasty            >=0.10 && <0.12
+                     , lens-family-core >=1.2  && <2.2
+                     , tasty            >=0.10 && <1.5
                      , tasty-golden     >=2.2  && <2.4
                      , barrier
   hs-source-dirs:      tests

--- a/barrier.cabal
+++ b/barrier.cabal
@@ -50,7 +50,7 @@ library
                      , unordered-containers >=0.2  && <0.3
                      , blaze-svg            >=0.3  && <0.4
                      , text                 >=1.1  && <1.3
-                     , bytestring           >=0.10 && <0.11
+                     , bytestring           >=0.10 && <0.12
   hs-source-dirs:      src
   ghc-options:         -Wall -O2
   default-language:    Haskell2010


### PR DESCRIPTION
Tested on GHC 9.6.2 using

    cabal run --enable-tests -c 'bytestring ^>= 0.12' -c 'lens-family-core ^>=2.1' \
      barrier-data-generator -fexample -fgenerator /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf \
      --allow-newer=hashable:bytestring --allow-newer=unix:bytestring
